### PR TITLE
Fix code in console-teleprompter tutorial

### DIFF
--- a/docs/csharp/tutorials/console-teleprompter.md
+++ b/docs/csharp/tutorials/console-teleprompter.md
@@ -383,10 +383,10 @@ use the `config` object for the delay:
 private static async Task ShowTeleprompter(TelePrompterConfig config)
 {
     var words = ReadFrom("sampleQuotes.txt");
-    foreach (var line in words)
+    foreach (var word in words)
     {
-        Console.Write(line);
-        if (!string.IsNullOrWhiteSpace(line))
+        Console.Write(word);
+        if (!string.IsNullOrWhiteSpace(word))
         {
             await Task.Delay(config.DelayInMilliseconds);
         }
@@ -400,9 +400,9 @@ private static async Task GetInput(TelePrompterConfig config)
     {
         do {
             var key = Console.ReadKey(true);
-            if (key.KeyChar == '>')
+            if (key.Key.ToString() == "LeftArrow")
                 config.UpdateDelay(-10);
-            else if (key.KeyChar == '<')
+            else if (key.Key.ToString() == "RightArrow")
                 config.UpdateDelay(10);
         } while (!config.Done);
     };


### PR DESCRIPTION
## Summary

1. Update variable name "line" to "word" to match previous **ShowTeleprompter()** code block.
2. Revise **ReadKey** code. 

    **Explanation:** I created the app per instructions (```dotnet new console -o myApp```) and opened it in Visual Studio 2017. Project properties shows that the **Target framework** is *.NET Core 2.1*. Arrow keys did not affect output speed.

    The topic [ConsoleKeyInfo.KeyChar Property](https://docs.microsoft.com/en-us/dotnet/api/system.consolekeyinfo.keychar?view=netcore-2.1#System_ConsoleKeyInfo_KeyChar) doesn't list keys that can or cannot be captured, but it *does* say that it applies to .NET Framework 4.7.2.

    The **KeyChar** topic in .NET Framework 4.7.2 documents **KeyChar** as part of the Windows.Forms namespace, but I'm assuming it will likely behave the same as **KeyChar** in the Console namespace.  According to the **Remarks** in the .NET Framework 4.7.2 [KeyPressEventArge.KeyChar Property](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.keypresseventargs.keychar?view=netframework-4.7.2) topic, you cannot use the **KeyChar** property to get the arrow keys.

    Proposed code change causes left and right arrow keys to function as intended.

